### PR TITLE
Refactoring of the DevSecOps Pipeline(s)

### DIFF
--- a/.github/workflows/devsecops_container_scanning.yml
+++ b/.github/workflows/devsecops_container_scanning.yml
@@ -1,4 +1,4 @@
-name: Security Scan Pipeline (Secret Scanning, SCA, SAST, IaC)
+name: Security Scan Pipeline (Secret Scanning, SCA, SAST, IaC, Container Scanning)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: '0 0 * * 1'  # Runs every Monday at midnight UTC
+    - cron: '0 0 * * *'  # Runs every day at midnight UTC
 
 permissions:
   contents: read
@@ -173,6 +173,70 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-iac_sarif-report.sarif'
+
+  # Container scanning with Trivy
+  container-scan:
+    name: Container Scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read            # Required for actions/checkout
+      security-events: write    # Required for uploading SARIF results
+      actions: read             # For fetching workflow statuses in private repositories
+    steps:
+      # Checkout repository (if Dockerfile is part of your repo)
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Build Docker image
+      - name: Build Docker Image
+        run: |
+          docker build -t rag .
+
+      # Set a dynamic file name for the report
+      - name: Set Trivy JSON report file name
+        run: echo "TRIVY_CONTAINER_REPORT_NAME=trivy-container-report_$(date +'%Y-%m-%d_%H-%M').json" >> $GITHUB_ENV
+
+      # Scan the Docker image with Trivy
+      - name: Run Trivy for Container Scanning, generate JSON vulnerability report
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'rag'
+          format: 'json'
+          # For now it is 0, will be promoted to 1
+          exit-code: '0'  # With exit-code:1 it fails if vulnerabilities are found
+          vuln-type: 'os,library' # default values
+          severity: 'CRITICAL,HIGH'
+          output: '${{ env.TRIVY_CONTAINER_REPORT_NAME }}'
+
+      # Upload the Trivy JSON report
+      - name: Upload Container Scanning results (JSON)
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-container_json-report
+          path: ${{ env.TRIVY_CONTAINER_REPORT_NAME }}
+          retention-days: 30
+
+      # Scan the Docker image with Trivy, create a SARIF report
+      - name: Run Trivy for Container Scanning, generate SARIF vulnerability report
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'rag'
+          format: 'sarif'
+          # For now it is 0, will be promoted to 1
+          exit-code: '0'  # With exit-code:1 it fails if vulnerabilities are found
+          # For the SARIF, only critical. Otherwise the GitHub Security tab will be flooded
+          severity: 'CRITICAL,HIGH'
+          output: 'trivy-container_sarif-report.sarif'
+          # On a subsequent call to the action we know Trivy is already installed so can skip this
+          skip-setup-trivy: true
+
+      # Upload SARIF results for Trivy Container Scan to GitHub Security tab
+      - name: Upload Trivy Container Scan Results (sarif)
+        uses: github/codeql-action/upload-sarif@v3
+        # Upload SARIF results to GitHub Code scanning even upon a non zero exit code from Trivy Scan
+        if: always()
+        with:
+          sarif_file: 'trivy-container_sarif-report.sarif'
 
 
 

--- a/.github/workflows/devsecops_container_scanning.yml
+++ b/.github/workflows/devsecops_container_scanning.yml
@@ -1,10 +1,6 @@
 name: Security Scan Pipeline (Secret Scanning, SCA, SAST, IaC, Container Scanning)
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
   schedule:
     - cron: '0 0 * * *'  # Runs every day at midnight UTC
 

--- a/.github/workflows/devsecops_container_scanning.yml
+++ b/.github/workflows/devsecops_container_scanning.yml
@@ -225,7 +225,7 @@ jobs:
           # For now it is 0, will be promoted to 1
           exit-code: '0'  # With exit-code:1 it fails if vulnerabilities are found
           # For the SARIF, only critical. Otherwise the GitHub Security tab will be flooded
-          severity: 'CRITICAL,HIGH'
+          severity: 'CRITICAL'
           output: 'trivy-container_sarif-report.sarif'
           # On a subsequent call to the action we know Trivy is already installed so can skip this
           skip-setup-trivy: true


### PR DESCRIPTION
Hello, I open this PR just to add an extra stage to the security pipeline. I apologize, but for brievity reasons the PR description is in italian. 

Ho aggiunto il container scanning alla vostra repo.
Per fare container scanning serve fare `docker build` ad uno stadio della pipeline, quindi ci mette un po' di tempo. Per questo ho messo il Container Scanning in una pipeline a parte, programmata in maniera tale da girare ogni giorno a mezzanotte (file `devsecops_container_scanning.yml`). Il file `devsecops.yml` (il file che esegue la security pipeline originale, diciamo così) non è stato cambiato.
Potrei creare della documentazione per la DevSecOps pipeline con questo nuovo stadio di container scanning, ma sarebbe praticamente uguale a quella della pipeline "originale" (che da voi manca. Ma è disponibile nella `demo-repository`).

Ecco un po' di cose da sapere:
- Viene creato un report in formato JSON. Per questo report, Trivy (il tool dietro la GitHub Action che fa i controlli di sicurezza) si concentra su livelli di vulnerabilità (`severity`) HIGH e CRITICAL
- Viene creato un report in formato sarif. Ovvero, vedete le cose nella tab Security della pagina web della repo di GitHub. Per questo report il livello di vulnerabilità è soltanto CRITICAL, perché c'erano veramente troppi (un centinaio, meno di altri gruppi...) alerts (per me) incomprensibili, relativi a problemi che (by the looks of it) non credo siano fixabili da noi. Quindi tanto vale ignorarli. Vedremo se dunque serve a qualcosa. Come al solito, cliccando sul collegamento (security tab -> Code scanning -> click sulla vulnerabilità specifica -> click sul link "CVE-.*") ci sono tutti i dettagli.
 - Cambiare questi comportamenti è facilissimo, basta editare i files

Se avete domande scrivetemi, proverò ad aiutarvi

P.S. vedo una vulnerabilità di livello alto nella vostra repo, riguarda il dockerfile e gli utenti. Vedete se si può fixare facilmente (ho uno strano presentimento...). Dovrebbe essere una cosa che è successa anche al gruppo 8, magari provo a chiedere a loro per vedere se è fixabile, almeno lavoro un po' anche io

P.P.S. vedo anche un errore segnalato da Bandit. Mi confermate che `explain_demo_dummy.py` è solamente un file per testare le capacità del modello, e non un file importante?
